### PR TITLE
Problem: tiles of first column are missing 

### DIFF
--- a/src/tiled/TMap.hx
+++ b/src/tiled/TMap.hx
@@ -55,7 +55,9 @@ class TMap {
 			var data = l.node.data;
 			switch( data.att.encoding ) {
 				case "csv" :
-					layer.setIds( data.innerHTML.split(",").map( function(id:String) : UInt {
+					// trim and remove eventual new lines.
+					var d = StringTools.trim(StringTools.replace(data.innerHTML,"\n", ""));
+					layer.setIds( d.split(",").map( function(id:String) : UInt {
 						var f = Std.parseFloat(id);
 						if( f > 2147483648. ) // dirty fix for Float>UInt casting issue when "bit #32" is set
 							return ( cast (f-2147483648.) : UInt ) | (1<<31);


### PR DESCRIPTION
Problem: tiles of the first column are missing 

I have created a small map with Tiled 1.3.3 and I noticed that the first row is not rendered.
I noticed that the csv section contains new-lines. The rendering looks correct after removing the new-lines.

Tested with:
- Haxe 4.0.5
- Tiles 1.3.3 
